### PR TITLE
feat: allow proxy for http sources to be unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,12 @@ The following parameters are available for all sources:
 
 Measures the http response time in milliseconds
 
-| Param      | Desc                                                                                      |
-|------------|-------------------------------------------------------------------------------------------|
-| url        | Url to the web service. Can be a list of strings as well (the url will be added as label) |
-| timeout    | Timeout in seconds (default 15)                                                           |
-| statusCode | The expected status code (default any non error)                                          |
-| proxy      | Http proxy which should be used (defaults to none)                                        |
+| Param      | Desc                                                                                                                                     |
+|------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| url        | Url to the web service. Can be a list of strings as well (the url will be added as label)                                                |
+| timeout    | Timeout in seconds (default 15)                                                                                                          |
+| statusCode | The expected status code (default any non error)                                                                                         |
+| proxy      | Http proxy which should be used (defaults to none respecting environment variables. Set to '' to use no proxy regardless of environment) |
 
 ## Disk usage `DiskUsage`
 

--- a/pollect/core/Helper.py
+++ b/pollect/core/Helper.py
@@ -22,7 +22,6 @@ def accept(include, exclude, value):
 
 
 def get_url(url, timeout: int = 5, expected_status: Optional[int] = None, proxy: Optional[str] = None):
-    session = requests.Session()
     proxies = None
     if proxy == '':
         parsed = urlparse(url)
@@ -36,7 +35,7 @@ def get_url(url, timeout: int = 5, expected_status: Optional[int] = None, proxy:
             'https': proxy
         }
 
-    response = session.get(url, timeout=(timeout, timeout), proxies=proxies)
+    response = requests.get(url, timeout=(timeout, timeout), proxies=proxies)
     status_code = response.status_code
     if expected_status is None:
         # Accept any "ok" status

--- a/pollect/core/Helper.py
+++ b/pollect/core/Helper.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from urllib.parse import urlparse
 
 import requests
 
@@ -24,8 +25,9 @@ def get_url(url, timeout: int = 5, expected_status: Optional[int] = None, proxy:
     session = requests.Session()
     proxies = None
     if proxy == '':
+        parsed = urlparse(url)
         proxies = {
-            'no_proxy': url
+            'no_proxy': parsed.hostname
         }
         pass
     elif proxy is not None:

--- a/pollect/core/Helper.py
+++ b/pollect/core/Helper.py
@@ -28,7 +28,6 @@ def get_url(url, timeout: int = 5, expected_status: Optional[int] = None, proxy:
         proxies = {
             'no_proxy': parsed.hostname
         }
-        pass
     elif proxy is not None:
         proxies = {
             'http': proxy,

--- a/pollect/core/Helper.py
+++ b/pollect/core/Helper.py
@@ -1,6 +1,6 @@
 from typing import Optional
-from urllib import request
-from urllib.error import HTTPError
+
+import requests
 
 
 def remove_empty_list(list_obj):
@@ -21,24 +21,25 @@ def accept(include, exclude, value):
 
 
 def get_url(url, timeout: int = 5, expected_status: Optional[int] = None, proxy: Optional[str] = None):
-    try:
-        req = request.Request(url)
-        if proxy is not None:
-            req.set_proxy(proxy, 'http')
-            req.set_proxy(proxy, 'https')
-        req.timeout = timeout
+    session = requests.Session()
+    proxies = None
+    if proxy == '':
+        proxies = {
+            'no_proxy': url
+        }
+        pass
+    elif proxy is not None:
+        proxies = {
+            'http': proxy,
+            'https': proxy
+        }
 
-        with request.urlopen(req) as url:
-            status_code = url.getcode()
-            if expected_status is None:
-                # Accept any "ok" status
-                if status_code < 200 or status_code >= 300:
-                    raise ValueError(f'Invalid status code {status_code}')
-            elif status_code != expected_status:
-                raise ValueError(f'Invalid status code {status_code}')
-            content = url.read()
-            return content
-    except HTTPError as e:
-        if expected_status is None and expected_status == e.status:
-            return e.read()
-        raise e
+    response = session.get(url, timeout=(timeout, timeout), proxies=proxies)
+    status_code = response.status_code
+    if expected_status is None:
+        # Accept any "ok" status
+        if status_code < 200 or status_code >= 300:
+            raise ValueError(f'Invalid status code {status_code}')
+    elif status_code != expected_status:
+        raise ValueError(f'Invalid status code {status_code}')
+    return response.text

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 .
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 .
-requests

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setuptools.setup(
     install_requires=[
         'schedule',
         'prometheus-client',
-        'PyYAML'
+        'PyYAML',
+        'requests'
     ],
     entry_points={
         'console_scripts': ['pollect=pollect.Pollect:main'],


### PR DESCRIPTION
Current behaviour:
- if a proxy is specified use this proxy
- else use the proxy configured in the environment (or none)

Improvement:
- if a proxy is set to an empty string use no proxy
- if a proxy is specified use this proxy
- else use the proxy configured in the environment (or none)

This allows for more complex setups where some probes might need the global proxy settings, but individual http probes must not use the globally set proxy