### PR TITLE
feat: add support for OtelWriter

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,22 @@ writer:
   cert: cert.pem
 ```
 
+## Otel http exporter `Otel
+
+Exports/Sends the data via OTLP (OpenTelemetry Protocol) over HTTP to a collector.
+
+```yaml
+writer:
+  type: Otel
+```
+
+You can use the common otel environment variables to configure the exporter.
+
+```bash
+export OTEL_EXPORTER_OTLP_HEADERS='Authorization=Basic xxx=='
+export OTEL_EXPORTER_OTLP_ENDPOINT='http://localhost:4318'
+```
+
 # Multithreading
 
 By default, pollect executes all sources of a collection in parallel with 5 threads.

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ You can use the common otel environment variables to configure the exporter.
 
 ```bash
 export OTEL_EXPORTER_OTLP_HEADERS='Authorization=Basic xxx=='
-export OTEL_EXPORTER_OTLP_ENDPOINT='http://localhost:4318'
+export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT='http://localhost:4318/v1/metrics'
 ```
 
 # Multithreading

--- a/pollect/writers/OtelWriter.py
+++ b/pollect/writers/OtelWriter.py
@@ -1,5 +1,5 @@
 
-from typing import List, Optional
+from typing import Dict, List, Optional
 from pollect.core.ValueSet import ValueSet, Value
 from pollect.sources.Source import Source
 from pollect.writers.Writer import Writer
@@ -28,17 +28,6 @@ class OtelWriter(Writer):
     def stop(self):
         pass
 
-    def get_metric_name(self, value_set: ValueSet, value_obj: Value):
-        """
-        Converts the value set and value object to a metric name
-        Replaces all invalid characters with underscores
-        """
-        metric_name = value_set.name
-        if value_obj.name is not None:
-            metric_name += '.' + value_obj.name
-        metric_name = metric_name.replace('-', '_').replace('.', '_').replace('!', '')
-        return metric_name
-
     def get_or_create_gauge(self, name: str):
         """
         Gets or creates a gauge with the given meter.
@@ -51,7 +40,7 @@ class OtelWriter(Writer):
         self.gauges[name] = gauge
         return gauge
     
-    def get_attributes_from_labels(self, labels: list, label_values: list):
+    def get_attributes_from_labels(self, labels: List[str], label_values: List[str]) -> Dict[str, str]:
         """
         Converts the labels used for prometheus to attributes used for opentelemetry
         """
@@ -63,7 +52,6 @@ class OtelWriter(Writer):
     def write(self, data: List[ValueSet], source_ref: Optional[Source] = None):
         for value_set in data:
             for value_obj in value_set.values:
-                metric_name = self.get_metric_name(value_set, value_obj)
-                gauge = self.get_or_create_gauge(metric_name)
+                gauge = self.get_or_create_gauge(value_set.name)
                 attributes = self.get_attributes_from_labels(value_set.labels, value_obj.label_values)
                 gauge.set(value_obj.value, attributes=attributes)

--- a/pollect/writers/OtelWriter.py
+++ b/pollect/writers/OtelWriter.py
@@ -1,0 +1,70 @@
+
+from typing import List, Optional
+from pollect.core.ValueSet import ValueSet, Value
+from pollect.sources.Source import Source
+from pollect.writers.Writer import Writer
+
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.metrics import ObservableGauge
+
+
+class OtelWriter(Writer):
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.exporter = OTLPMetricExporter()
+        self.reader = PeriodicExportingMetricReader(self.exporter)
+        self.provider = MeterProvider(metric_readers=[self.reader])
+
+        self.meter = self.provider.get_meter('pollect')
+
+        self.gauges = {}
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def get_metric_name(self, value_set: ValueSet, value_obj: Value):
+        """
+        Converts the value set and value object to a metric name
+        Replaces all invalid characters with underscores
+        """
+        print(type(value_obj))
+        metric_name = value_set.name
+        if value_obj.name is not None:
+            metric_name += '.' + value_obj.name
+        metric_name = metric_name.replace('-', '_').replace('.', '_').replace('!', '')
+        return metric_name
+
+    def get_or_create_gauge(self, name: str):
+        """
+        Gets or creates a gauge with the given meter.
+        There is no inbuilt way to obtain a gauge from the meter, so we store them in a dictionary
+        """
+        if name in self.gauges.keys():
+            return self.gauges[name]
+        
+        gauge = self.meter.create_gauge(name=name)
+        self.gauges[name] = gauge
+        return gauge
+    
+    def get_attributes_from_labels(self, labels: list, label_values: list):
+        """
+        Converts the labels used for prometheus to attributes used for opentelemetry
+        """
+        attributes = {}
+        for i in range(len(labels)):
+            attributes[labels[i]] = label_values[i]
+        return attributes
+
+    def write(self, data: List[ValueSet], source_ref: Optional[Source] = None):
+        for value_set in data:
+            for value_obj in value_set.values:
+                metric_name = self.get_metric_name(value_set, value_obj)
+                gauge = self.get_or_create_gauge(metric_name)
+                attributes = self.get_attributes_from_labels(value_set.labels, value_obj.label_values)
+                gauge.set(value_obj.value, attributes=attributes)

--- a/pollect/writers/OtelWriter.py
+++ b/pollect/writers/OtelWriter.py
@@ -33,7 +33,6 @@ class OtelWriter(Writer):
         Converts the value set and value object to a metric name
         Replaces all invalid characters with underscores
         """
-        print(type(value_obj))
         metric_name = value_set.name
         if value_obj.name is not None:
             metric_name += '.' + value_obj.name

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,9 @@ setuptools.setup(
         'schedule',
         'prometheus-client',
         'PyYAML',
-        'requests'
+        'requests',
+        'opentelemetry-sdk',
+        'opentelemetry-exporter-otlp',
     ],
     entry_points={
         'console_scripts': ['pollect=pollect.Pollect:main'],

--- a/tests/writers/test_OtelWriter.py
+++ b/tests/writers/test_OtelWriter.py
@@ -1,0 +1,32 @@
+from unittest import TestCase
+
+
+from pollect.core.ValueSet import ValueSet
+from pollect.writers.OtelWriter import OtelWriter
+
+
+class TestOtelWriter(TestCase):
+    writer: OtelWriter = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        # Singleton
+        if TestOtelWriter.writer is None:
+            TestOtelWriter.writer = OtelWriter({'port': 9123})
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        TestOtelWriter
+
+    def test_get_attributes_from_labels(self):
+        labels = ['a', 'b']
+        label_values = ['1', '2']
+        attributes = TestOtelWriter.writer.get_attributes_from_labels(labels, label_values)
+       
+        assert attributes == {'a': '1', 'b': '2'}
+
+    def test_get_or_create_gauge(self):
+        # Execute twice to test if on first call the gauge is created and on the second the existing gauge is returned
+        gauge = TestOtelWriter.writer.get_or_create_gauge('test')
+        gauge = TestOtelWriter.writer.get_or_create_gauge('test')
+        assert self.writer.gauges['test'] == gauge


### PR DESCRIPTION
This PR adds the capability of an OtelWriter to Pollect. This will allow instead of exposing the metrics at a local port to send them to a otel collector.

## Local reproducing

### Otel Collector

You can run a otel collector + Prometheus locally to test this setup

```yaml
# otel-config.yml
receivers:
  otlp:
    protocols:
      http:
        endpoint: "0.0.0.0:4318"
  
exporters:
  prometheus:
    endpoint: "0.0.0.0:8899"

service:
  pipelines:
    metrics:
      receivers: [otlp]
      processors: [batch]
      exporters: [prometheus]
```

Run otel collector locally in a container

```bash
docker run --rm --name otel-collector -p 4318:4318 -p 8899:8899 -v $(pwd)/otel-collector-config.yml:/otel-config.yml otel/opentelemetry-collector:latest --config /otel-config.yml
```

### Prometheus

```yaml
# prometheus.yml
global:
  scrape_interval: 10s

scrape_configs:
  - job_name: 'otel-collector'
    scrape_interval: 5s
    static_configs:
      - targets: ['otel-collector:8899']
    scrape_timeout: 1s
```

Run prometheus locally in container

```yaml
docker run --rm \                                                                                                                                                                             
  --name prometheus \
  -p 9090:9090 \
  -v $(pwd)/prometheus.yml:/etc/prometheus/prometheus.yml \
  prom/prometheus
```

### Pollect

Running with simple `config.yml`

```yaml
---
tickTime: 1
threads: 4
writer:
  type: Otel
executors:
  - collection: pollect
    sources:
      - type: LoadAvg
```

```bash
pollect --config config.yml
```

![image](https://github.com/user-attachments/assets/51dd2ebb-154e-4666-a1d7-65364cbd262b)



