### PR TITLE
Upgrade to python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM python:3.9-slim-buster
+FROM python:3.11-slim-bookworm
 
 WORKDIR /app
 COPY requirements-docker.txt .
 COPY dist/pollect*.whl .
-RUN pip install *.whl && \
+RUN pip install ./*.whl && \
 	pip install -r requirements-docker.txt && \
-	rm *.whl
+	rm ./*.whl
 
 
-ENV PYTHONPATH "${PYTHONPATH}:/pollect"
+ENV PYTHONPATH="${PYTHONPATH}:/pollect"
 CMD ["python", "-m", "pollect.Pollect", "--config", "/pollect/config"]


### PR DESCRIPTION
Python 3.9 is nearing it's **end of security support** in 2025:
https://devguide.python.org/versions/

This upgrade also upgrades the **Debian** version to reduce the number of **vulnerabilities**.