### PR TITLE
fix(SnmpGetSource): build arg version check in int

### DIFF
--- a/pollect/sources/SnmpGetSource.py
+++ b/pollect/sources/SnmpGetSource.py
@@ -260,7 +260,7 @@ class SnmpGetSource(Source):
         return values
 
     def _build_args(self) -> List[str]:
-        if self.snmp_version == '3':
+        if self.snmp_version == 3:
             return [
                 'snmpget',
                 '-v', self.snmp_version,


### PR DESCRIPTION
```bash
  File "/usr/local/lib/python3.11/site-packages/pollect/sources/Source.py", line 60, in probe
    results = self._probe()
              ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pollect/sources/SnmpGetSource.py", line 218, in _probe
    snmp_values = self._get_values(self.oids)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pollect/sources/SnmpGetSource.py", line 240, in _get_values
    args = self._build_args()
           ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pollect/sources/SnmpGetSource.py", line 279, in _build_args
    '-c', self.community,
          ^^^^^^^^^^^^^^
AttributeError: 'SnmpGetSource' object has no attribute 'community'
E 2024-11-25 14:57:21 [Executor] Error while probing using source pollect/SnmpGet.prod: 'SnmpGetSource' object has no attribute 'community'
```

When using a config with snmp and yaml, this will go to the `else` since ('3' != 3)
```yaml
snmpVersion: 3
```

Whereas when you set 

```yaml
snmpVersion: '3'
```

it will go to version 1 in the init as there its a int comparison

https://github.com/davidgiga1993/pollect/blob/b61e5a54ef25ed541fd037c3578cb0a9c593c779/pollect/sources/SnmpGetSource.py#L207