### PR TITLE
fix(SnmpGetSource): check_output with str

### DIFF
--- a/pollect/sources/SnmpGetSource.py
+++ b/pollect/sources/SnmpGetSource.py
@@ -239,7 +239,7 @@ class SnmpGetSource(Source):
 
         args = self._build_args()
         args.extend(oids)
-        lines = subprocess.check_output(args).decode('utf-8').splitlines()
+        lines = subprocess.check_output([str(x) for x in args]).decode('utf-8').splitlines()
 
         values = {}
         for line in lines:


### PR DESCRIPTION
```bash
Traceback (most recent call last):
I 2024-11-26 05:21:51 [Executor] Collecting data from ghes_nginx_metrics/src.ghes.ghes_nginx
  File "/usr/local/lib/python3.11/site-packages/pollect/core/Core.py", line 177, in _probe
    value_sets = source.probe()
                 ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pollect/sources/Source.py", line 60, in probe
    results = self._probe()
              ^^^^^^^^^^^^^
I 2024-11-26 05:21:51 [Executor] Collecting data from ghes_nginx_metrics/src.ghes.ghes_nginx
  File "/usr/local/lib/python3.11/site-packages/pollect/sources/SnmpGetSource.py", line 218, in _probe
    snmp_values = self._get_values(self.oids)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pollect/sources/SnmpGetSource.py", line 242, in _get_values
    lines = subprocess.check_output(args).decode('utf-8').splitlines()
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/subprocess.py", line 548, in run
    with Popen(*popenargs, **kwargs) as process:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/local/lib/python3.11/subprocess.py", line 1885, in _execute_child
    self.pid = _fork_exec(
               ^^^^^^^^^^^
TypeError: expected str, bytes or os.PathLike object, not int
E 2024-11-26 05:21:51 [Executor] Error while probing using source pollect/SnmpGet.dev: expected str, bytes or os.PathLike object, not int
```

Since `snmp_version` was changed to a number in https://github.com/davidgiga1993/pollect/pull/41 we need to cast the args to strings, since the `subprocess.checkout_output` method only allows str, bytes or os.PathLike 

