### PR TITLE
fix(OtelWriter): metric names in collections and otel number values

### DIFF
--- a/pollect/writers/OtelWriter.py
+++ b/pollect/writers/OtelWriter.py
@@ -30,9 +30,17 @@ class OtelWriter(Writer):
     def write(self, data: List[ValueSet], source_ref: Optional[Source] = None):
         for value_set in data:
             for value_obj in value_set.values:
-                gauge = self._get_or_create_gauge(value_set.name)
+                metric_name = value_set.name
+                if value_obj.name is not None:
+                    metric_name += "_" + value_obj.name
+
+                gauge = self._get_or_create_gauge(metric_name)
                 attributes = self._get_attributes_from_labels(value_set.labels, value_obj.label_values)
-                gauge.set(value_obj.value, attributes=attributes)
+                try:
+                    value = float(value_obj.value)
+                    gauge.set(value, attributes=attributes)
+                except ValueError:
+                    print(f"Could not convert value {value_obj.value} to float")
 
     def _get_or_create_gauge(self, name: str) -> ObservableGauge:
         """

--- a/pollect/writers/OtelWriter.py
+++ b/pollect/writers/OtelWriter.py
@@ -40,7 +40,7 @@ class OtelWriter(Writer):
                     value = float(value_obj.value)
                     gauge.set(value, attributes=attributes)
                 except ValueError:
-                    print(f"Could not convert value {value_obj.value} to float")
+                    self.log.error(f"Could not convert value {value_obj.value} to float")
 
     def _get_or_create_gauge(self, name: str) -> ObservableGauge:
         """


### PR DESCRIPTION
- Fix that you can use multiple metrics per collection and metric name is resolved
- Fix that value is transformed into float since Otel does not support strings

```bash
opentelemetry.exporter.otlp.proto.common._internal.metrics_encoder.EncodingException: Metric(name='pollect.snmpget.qa_laload1min', description='', unit='', data=Gauge(data_points=[NumberDataPoint(attributes={}, start_time_unix_nano=None, time_unix_nano=1732870758992103261, value='6.93', exemplars=[])]))
must be real number, not str
```